### PR TITLE
Error if no project is set when calling a find-file command

### DIFF
--- a/projectable.el
+++ b/projectable.el
@@ -554,6 +554,10 @@ Optionally called F as the function used to switch the buffer."
 Select a file matched using `completing-read` against the contents
 of FILE-ALIST.  Options are displayed using READ-F.  If the file exists
 in more than one directory, select directory.  Lastly the file is opened using FIND-F."
+
+  (unless projectable-id
+    (error "ERROR: You haven't set a project yet, set a project by calling projectable-find-file (C-x p c)"))
+
   (let* ((file (completing-read "File: " (mapcar projectable-completion-func file-alist)))
          (record (assoc (file-name-nondirectory file) file-alist)))
     (funcall find-f


### PR DESCRIPTION
If a user tries to call any of the find-file
commands (e.g. projectable-find-file) when a project isn't set, the
result is as though the user is in an empty project (e.g. the user is
given the choice to choose a file when none exist). Now,
projectable--find-file will error if projectable-id is nil.
